### PR TITLE
Updated Rewrite to 2.0.4 to get Asciidoctor 0.1.2 with TOC macro support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.6</maven.compiler.source>
 		<maven.compiler.target>1.6</maven.compiler.target>
-		<version.rewrite>2.0.0.Final</version.rewrite>
+		<version.rewrite>2.0.4.Final</version.rewrite>
 		<version.jgit>2.3.1.201302201838-r</version.jgit>
 		<version.junit>4.8.1</version.junit>
 		<version.gson>2.2.2</version.gson>


### PR DESCRIPTION
I updated Rewrite to get Asciidoctor 0.1.2 which now support a TOC macro:

https://github.com/asciidoctor/asciidoctor/issues/269

I think this will be useful. 
